### PR TITLE
Added snmpApp_DEPEND_DIRS = devSnmpApp to ensure proper build order.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,7 @@ DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *App))
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *app))
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocBoot))
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocboot))
+
+snmpApp_DEPEND_DIRS = devSnmpApp
+
 include $(TOP)/configure/RULES_TOP


### PR DESCRIPTION
The builds have been fine for our RHEL5 and RHEL6 systems, but when I went to RHEL7 it tried to build snmpApp before devSnmpApp.   Probably a subtle change in how gnu make handles wildcard.